### PR TITLE
Fix test failures due to jest includes pattern

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,3 +19,4 @@ jobs:
         node-version: 12.x
     - run: npm ci
     - run: npm run build --if-present
+    - run: npm test

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "jest --coverage --verbose",
+    "test": "jest --coverage --verbose --testPathPattern=.*\\.test\\.ts$",
     "build": "concurrently \"npm run build:client\" \"npm run build:server\"",
     "dev:client": "webpack-dev-server --env development",
     "build:client": "webpack --env production",


### PR DESCRIPTION
Jest fail locally because it also tries to tun a tests from `/dist/**/*.test.js` in addition to `/src/**/test.ts`.

We did not catch this in PR because the github action did not include test. Fixed that as well.  

```
> jest --coverage --verbose

 FAIL  src/server/dist/services/search/providers/OpenCageDataProvider.test.js
  OpenCageDataProvider
    ✕ an empty query string (2 ms)
    ✕ an invalid non-json response

  ● OpenCageDataProvider › an empty query string

    TypeError: got_1.default.mockResolvedValue is not a function

       6 | describe('OpenCageDataProvider', () => {
       7 |   test('an empty query string', async () => {
    >  8 |     (got as any).mockResolvedValue({ body: '{"features": []}' });
         |                  ^
       9 |     const result = await getPlaces('Paris');
      10 |     expect(result).toEqual({ features: [] });
      11 |   });

      at src/server/services/search/providers/OpenCageDataProvider.test.ts:8:18
      at src/server/dist/services/search/providers/OpenCageDataProvider.test.js:8:71
      at __awaiter (src/server/dist/services/search/providers/OpenCageDataProvider.test.js:4:12)
      at Object.<anonymous> (src/server/services/search/providers/OpenCageDataProvider.test.ts:7:44)

  ● OpenCageDataProvider › an invalid non-json response

    TypeError: got_1.default.mockResolvedValue is not a function

      12 |
      13 |   test('an invalid non-json response', async () => {
    > 14 |     (got as any).mockResolvedValue('Service Unavailable.');
         |                  ^
      15 |     await expect(getPlaces('Chamonix')).rejects.toThrow(SyntaxError);
      16 |   });
      17 | });

      at src/server/services/search/providers/OpenCageDataProvider.test.ts:14:18
      at src/server/dist/services/search/providers/OpenCageDataProvider.test.js:8:71
      at __awaiter (src/server/dist/services/search/providers/OpenCageDataProvider.test.js:4:12)
      at Object.<anonymous> (src/server/services/search/providers/OpenCageDataProvider.test.ts:13:51)

 PASS  src/server/services/search/providers/OpenCageDataProvider.test.ts
  OpenCageDataProvider
    ✓ an empty query string (2 ms)
    ✓ an invalid non-json response (2 ms)
```